### PR TITLE
urdf: switch from TinyXML to TinyXML2

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   urdf_parser_plugin pluginlib rosconsole_bridge roscpp cmake_modules)
 
 
-find_package(TinyXML REQUIRED)
+find_package(TinyXML2 REQUIRED)
 
 # Find version components
 if(NOT urdfdom_headers_VERSION)
@@ -27,7 +27,7 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
   CATKIN_DEPENDS rosconsole_bridge roscpp
-  DEPENDS urdfdom_headers urdfdom Boost TinyXML
+  DEPENDS urdfdom_headers urdfdom Boost TinyXML2
 )
 install(FILES ${generated_compat_header} DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
@@ -37,13 +37,13 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
   ${urdfdom_INCLUDE_DIRS}
   ${urdfdom_headers_INCLUDE_DIRS}
-  ${TinyXML_INCLUDE_DIRS}
+  ${TinyXML2_INCLUDE_DIRS}
   )
 
 link_directories(${Boost_LIBRARY_DIRS} ${catkin_LIBRARY_DIRS})
 
 add_library(${PROJECT_NAME} src/model.cpp src/rosconsole_bridge.cpp)
-target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${TinyXML2_LIBRARIES} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
 
 if(APPLE)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -41,7 +41,7 @@
 #include <map>
 #include <urdf_model/model.h>
 #include <urdf/urdfdom_compatibility.h>
-#include <tinyxml.h>
+#include <tinyxml2.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 #include <ros/ros.h>
@@ -51,10 +51,10 @@ namespace urdf{
 class Model: public ModelInterface
 {
 public:
-  /// \brief Load Model from TiXMLElement
-  bool initXml(TiXmlElement *xml);
-  /// \brief Load Model from TiXMLDocument
-  bool initXml(TiXmlDocument *xml);
+  /// \brief Load Model from XMLElement
+  bool initXml(tinyxml2::XMLElement *xml);
+  /// \brief Load Model from XMLDocument
+  bool initXml(tinyxml2::XMLDocument *xml);
   /// \brief Load Model given a filename
   bool initFile(const std::string& filename);
   /// \brief Load Model given the name of a parameter on the parameter server

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -50,6 +50,8 @@
 #include <fstream>
 #include <iostream>
 
+using namespace tinyxml2;
+
 namespace urdf{
 
 static bool IsColladaData(const std::string& data)
@@ -108,7 +110,7 @@ bool Model::initParamWithNodeHandle(const std::string& param, const ros::NodeHan
   return Model::initString(xml_string);
 }
 
-bool Model::initXml(TiXmlDocument *xml_doc)
+bool Model::initXml(XMLDocument *xml_doc)
 {
   if (!xml_doc)
   {
@@ -116,13 +118,14 @@ bool Model::initXml(TiXmlDocument *xml_doc)
     return false;
   }
 
-  std::stringstream ss;
-  ss << *xml_doc;
+  XMLPrinter printer;
+  xml_doc->Print(&printer);
+  std::string str(printer.CStr());
 
-  return Model::initString(ss.str());
+  return Model::initString(str);
 }
 
-bool Model::initXml(TiXmlElement *robot_xml)
+bool Model::initXml(XMLElement *robot_xml)
 {
   if (!robot_xml)
   {
@@ -131,7 +134,9 @@ bool Model::initXml(TiXmlElement *robot_xml)
   }
 
   std::stringstream ss;
-  ss << (*robot_xml);
+  XMLPrinter printer;
+  robot_xml->Accept(&printer);
+  ss << printer.CStr();
 
   return Model::initString(ss.str());
 }


### PR DESCRIPTION
The library TinyXML is considered to be unmaintained and
since all future development is focused on TinyXML2 this
patch updates urdf to use TinyXML2.

This is a followup from https://github.com/ros/robot_model/pull/205