### PR TITLE
Add a exec dependency to enable check_urdf.

### DIFF
--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -31,6 +31,7 @@
   <build_depend>tinyxml</build_depend>
 
   <exec_depend>liburdfdom-dev</exec_depend>
+  <exec_depend>liburdfdom-tools</exec_depend>
   <exec_depend>rosconsole_bridge</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>pluginlib</exec_depend>


### PR DESCRIPTION
http://wiki.ros.org/urdf#Verification introduces a tool `check_urdf` that requires this dependency. This tool used to be a part of `urdf` AFAIR and today it took me some time to figure out why a test that depends on that tool fails on CI even though the pkg depends on ROS urdf pkg. It'd be nice to have this dependency for convenience.