### PR TITLE
Tinyxml2 support

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -59,10 +59,10 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(test_urdf_parser ${PROJECT_NAME})
 
   catkin_add_gtest(urdfdom_compatibility_test test/urdfdom_compatibility.cpp)
-endif()
 
-# no idea how CATKIN does this
-# rosbuild_add_rostest(${PROJECT_SOURCE_DIR}/test/test_robot_model_parser.launch)
+  catkin_add_gtest(test_model_parser_initxml test/test_model_parser_initxml.cpp)
+  target_link_libraries(test_model_parser_initxml ${PROJECT_NAME})
+endif()
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 
 find_package(TinyXML REQUIRED)
+find_package(TinyXML2 REQUIRED)
 
 # Find version components
 if(NOT urdfdom_headers_VERSION)
@@ -27,7 +28,7 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
   CATKIN_DEPENDS rosconsole_bridge roscpp
-  DEPENDS urdfdom_headers urdfdom Boost TinyXML
+  DEPENDS urdfdom_headers urdfdom Boost TinyXML TinyXML2
 )
 install(FILES ${generated_compat_header} DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
@@ -38,12 +39,13 @@ include_directories(
   ${urdfdom_INCLUDE_DIRS}
   ${urdfdom_headers_INCLUDE_DIRS}
   ${TinyXML_INCLUDE_DIRS}
+  ${TinyXML2_INCLUDE_DIRS}
   )
 
 link_directories(${Boost_LIBRARY_DIRS} ${catkin_LIBRARY_DIRS})
 
 add_library(${PROJECT_NAME} src/model.cpp src/rosconsole_bridge.cpp)
-target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${TinyXML2_LIBRARIES} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
 
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME} PRIVATE "URDF_BUILDING_LIBRARY")
@@ -60,6 +62,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gtest(urdfdom_compatibility_test test/urdfdom_compatibility.cpp)
 
+  set_source_files_properties(test/test_model_parser_initxml.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
   catkin_add_gtest(test_model_parser_initxml test/test_model_parser_initxml.cpp)
   target_link_libraries(test_model_parser_initxml ${PROJECT_NAME})
 endif()

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -40,10 +40,11 @@
 #include <string>
 
 #include <urdf_model/model.h>
+
 #include <urdf/urdfdom_compatibility.h>
+
 #include <tinyxml.h>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
+
 #include <ros/ros.h>
 
 #include "urdf/visibility_control.hpp"

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -45,6 +45,8 @@
 
 #include <tinyxml.h>
 
+#include <tinyxml2.h>
+
 #include <ros/ros.h>
 
 #include "urdf/visibility_control.hpp"
@@ -56,9 +58,13 @@ class Model : public ModelInterface
 {
 public:
   /// \brief Load Model from TiXMLElement
-  URDF_EXPORT bool initXml(TiXmlElement * xml);
+  URDF_EXPORT URDF_DEPRECATED("TinyXML API is deprecated, use the TinyXML2 version instead") bool initXml(TiXmlElement * xml);
   /// \brief Load Model from TiXMLDocument
-  URDF_EXPORT bool initXml(TiXmlDocument * xml);
+  URDF_EXPORT URDF_DEPRECATED("TinyXML API is deprecated, use the TinyXML2 version instead") bool initXml(TiXmlDocument * xml);
+  /// \brief Load Model from tinyxml2::XMLElement
+  URDF_EXPORT bool initXml(tinyxml2::XMLElement *xml);
+  /// \brief Load Model from tinyxml2::XMLDocument
+  URDF_EXPORT bool initXml(tinyxml2::XMLDocument *xml);
   /// \brief Load Model given a filename
   URDF_EXPORT bool initFile(const std::string & filename);
   /// \brief Load Model given the name of a parameter on the parameter server

--- a/urdf/include/urdf/visibility_control.hpp
+++ b/urdf/include/urdf/visibility_control.hpp
@@ -49,9 +49,11 @@
   #ifdef __GNUC__
     #define URDF_EXPORT __attribute__ ((dllexport))
     #define URDF_IMPORT __attribute__ ((dllimport))
+    #define URDF_DEPRECATED(msg) __attribute__((deprecated(msg)))
   #else
     #define URDF_EXPORT __declspec(dllexport)
     #define URDF_IMPORT __declspec(dllimport)
+    #define URDF_DEPRECATED(msg) __attribute__((deprecated(msg)))
   #endif
   #ifdef URDF_BUILDING_LIBRARY
     #define URDF_PUBLIC URDF_EXPORT
@@ -63,6 +65,7 @@
 #else
   #define URDF_EXPORT __attribute__ ((visibility("default")))
   #define URDF_IMPORT
+  #define URDF_DEPRECATED(msg) __attribute__((deprecated(msg)))
   #if __GNUC__ >= 4
     #define URDF_PUBLIC __attribute__ ((visibility("default")))
     #define URDF_LOCAL  __attribute__ ((visibility("hidden")))

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -29,14 +29,17 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>tinyxml</build_depend>
+  <build_depend>tinyxml2</build_depend>
 
   <exec_depend>liburdfdom-dev</exec_depend>
   <exec_depend>rosconsole_bridge</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>tinyxml</exec_depend>
+  <exec_depend>tinyxml2</exec_depend>
 
   <build_export_depend>tinyxml</build_export_depend>
+  <build_export_depend>tinyxml2</build_export_depend>
   <build_export_depend>liburdfdom-headers-dev</build_export_depend>
 
   <test_depend>rostest</test_depend>

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -51,6 +51,8 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>
 
+#include <tinyxml.h>
+
 namespace urdf
 {
 

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -52,6 +52,7 @@
 #include <boost/thread.hpp>
 
 #include <tinyxml.h>
+#include <tinyxml2.h>
 
 namespace urdf
 {
@@ -127,6 +128,35 @@ bool Model::initXml(TiXmlElement * robot_xml)
 
   std::stringstream ss;
   ss << (*robot_xml);
+
+  return Model::initString(ss.str());
+}
+
+bool Model::initXml(tinyxml2::XMLDocument *xml_doc)
+{
+  if (!xml_doc) {
+    ROS_ERROR("Could not parse the xml document");
+    return false;
+  }
+
+  tinyxml2::XMLPrinter printer;
+  xml_doc->Print(&printer);
+  std::string str(printer.CStr());
+
+  return Model::initString(str);
+}
+
+bool Model::initXml(tinyxml2::XMLElement *robot_xml)
+{
+  if (!robot_xml) {
+    ROS_ERROR("Could not parse the xml element");
+    return false;
+  }
+
+  std::stringstream ss;
+  tinyxml2::XMLPrinter printer;
+  robot_xml->Accept(&printer);
+  ss << printer.CStr();
 
   return Model::initString(ss.str());
 }

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -141,26 +141,27 @@ bool Model::initString(const std::string & xml_string)
     static boost::scoped_ptr<pluginlib::ClassLoader<urdf::URDFParser> > PARSER_PLUGIN_LOADER;
     boost::mutex::scoped_lock _(PARSER_PLUGIN_LOCK);
 
-    try
-    {
-      if (!PARSER_PLUGIN_LOADER)
-	PARSER_PLUGIN_LOADER.reset(new pluginlib::ClassLoader<urdf::URDFParser>("urdf_parser_plugin", "urdf::URDFParser"));
+    try {
+      if (!PARSER_PLUGIN_LOADER) {
+        PARSER_PLUGIN_LOADER.reset(new pluginlib::ClassLoader<urdf::URDFParser>("urdf_parser_plugin", "urdf::URDFParser"));
+      }
       const std::vector<std::string> &classes = PARSER_PLUGIN_LOADER->getDeclaredClasses();
       bool found = false;
-      for (std::size_t i = 0 ; i < classes.size() ; ++i)
-	if (classes[i].find("urdf/ColladaURDFParser") != std::string::npos)
-	{
-	  boost::shared_ptr<urdf::URDFParser> instance = PARSER_PLUGIN_LOADER->createInstance(classes[i]);
-	  if (instance)
-	    model = instance->parse(xml_string);
-	  found = true;
-	  break;
-	}
-      if (!found)
-	ROS_ERROR_STREAM("No URDF parser plugin found for Collada files. Did you install the corresponding package?");
+      for (std::size_t i = 0 ; i < classes.size() ; ++i) {
+        if (classes[i].find("urdf/ColladaURDFParser") != std::string::npos) {
+          boost::shared_ptr<urdf::URDFParser> instance = PARSER_PLUGIN_LOADER->createInstance(classes[i]);
+          if (instance) {
+            model = instance->parse(xml_string);
+          }
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        ROS_ERROR_STREAM("No URDF parser plugin found for Collada files. Did you install the corresponding package?");
+      }
     }
-    catch(pluginlib::PluginlibException& ex)
-    {
+    catch(pluginlib::PluginlibException& ex) {
       ROS_ERROR_STREAM("Exception while creating planning plugin loader " << ex.what() << ". Will not parse Collada file.");
     }
   } else {

--- a/urdf/test/test_model_parser_initxml.cpp
+++ b/urdf/test/test_model_parser_initxml.cpp
@@ -85,6 +85,36 @@ TEST(model_parser_initxml, initxml_tinyxml_document_good)
   ASSERT_TRUE(model.initXml(&xml_doc));
 }
 
+TEST(model_parser_initxml, initxml_tinyxml2_element_bad)
+{
+  urdf::Model model;
+  ASSERT_FALSE(model.initXml(reinterpret_cast<tinyxml2::XMLElement *>(NULL)));
+}
+
+TEST(model_parser_initxml, initxml_tinyxml2_element_good)
+{
+  tinyxml2::XMLDocument xml_doc;
+  xml_doc.Parse(good_robot.c_str());
+
+  urdf::Model model;
+  ASSERT_TRUE(model.initXml(xml_doc.RootElement()));
+}
+
+TEST(model_parser_initxml, initxml_tinyxml2_document_bad)
+{
+  urdf::Model model;
+  ASSERT_FALSE(model.initXml(reinterpret_cast<tinyxml2::XMLDocument *>(NULL)));
+}
+
+TEST(model_parser_initxml, initxml_tinyxml2_document_good)
+{
+  tinyxml2::XMLDocument xml_doc;
+  xml_doc.Parse(good_robot.c_str());
+
+  urdf::Model model;
+  ASSERT_TRUE(model.initXml(&xml_doc));
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/urdf/test/test_model_parser_initxml.cpp
+++ b/urdf/test/test_model_parser_initxml.cpp
@@ -1,0 +1,92 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2018, Open Source Robotics Foundation
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "urdf/model.h"
+
+static const std::string good_robot{"<robot name=\"myrobot\">"
+                                    "  <link>"
+                                    "  </link>"
+                                    "</robot>"};
+
+TEST(model_parser_initxml, initstring_bad_xml)
+{
+  const std::string robot{""};
+
+  urdf::Model model;
+  ASSERT_FALSE(model.initString(robot));
+}
+
+TEST(model_parser_initxml, initstring_good)
+{
+  urdf::Model model;
+  ASSERT_TRUE(model.initString(good_robot));
+}
+
+TEST(model_parser_initxml, initxml_tinyxml_element_bad)
+{
+  urdf::Model model;
+  ASSERT_FALSE(model.initXml(reinterpret_cast<TiXmlElement *>(NULL)));
+}
+
+TEST(model_parser_initxml, initxml_tinyxml_element_good)
+{
+  TiXmlDocument xml_doc;
+  xml_doc.Parse(good_robot.c_str());
+
+  urdf::Model model;
+  ASSERT_TRUE(model.initXml(xml_doc.RootElement()));
+}
+
+TEST(model_parser_initxml, initxml_tinyxml_document_bad)
+{
+  urdf::Model model;
+  ASSERT_FALSE(model.initXml(reinterpret_cast<TiXmlDocument *>(NULL)));
+}
+
+TEST(model_parser_initxml, initxml_tinyxml_document_good)
+{
+  TiXmlDocument xml_doc;
+  xml_doc.Parse(good_robot.c_str());
+
+  urdf::Model model;
+  ASSERT_TRUE(model.initXml(&xml_doc));
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Based on this [comment](https://github.com/ros/urdf/pull/4/files#r169813112) this PR is an alternative to #4.  Instead of removing the TinyXML APIs completely, we deprecate them and add the TinyXML2 APIs alongside.  That way we won't break everything that depends on us, while still moving forward.  Sometime in the future we can actually remove the TinyXML APIs.

Note that I've targeted this at `kinetic-devel` instead of `melodic-devel`, since we can add this to kinetic without breaking anything, and thus not branch off.  If we decide to go with this PR, then we can delete the `melodic-devel` branch completely.

In addition to this work, this PR also cleans up the code and adds some tests.

@rojkov, @sloretz FYI