### PR TITLE
Changed tinyxml2 parameter to be const reference

### DIFF
--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -62,9 +62,9 @@ public:
   /// \brief Load Model from TiXMLDocument
   URDF_EXPORT URDF_DEPRECATED("TinyXML API is deprecated, use the TinyXML2 version instead") bool initXml(TiXmlDocument * xml);
   /// \brief Load Model from tinyxml2::XMLElement
-  URDF_EXPORT bool initXml(tinyxml2::XMLElement *xml);
+  URDF_EXPORT bool initXml(const tinyxml2::XMLElement & xml);
   /// \brief Load Model from tinyxml2::XMLDocument
-  URDF_EXPORT bool initXml(tinyxml2::XMLDocument *xml);
+  URDF_EXPORT bool initXml(const tinyxml2::XMLDocument & xml);
   /// \brief Load Model given a filename
   URDF_EXPORT bool initFile(const std::string & filename);
   /// \brief Load Model given the name of a parameter on the parameter server

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -132,30 +132,20 @@ bool Model::initXml(TiXmlElement * robot_xml)
   return Model::initString(ss.str());
 }
 
-bool Model::initXml(tinyxml2::XMLDocument *xml_doc)
+bool Model::initXml(const tinyxml2::XMLDocument & xml_doc)
 {
-  if (!xml_doc) {
-    ROS_ERROR("Could not parse the xml document");
-    return false;
-  }
-
   tinyxml2::XMLPrinter printer;
-  xml_doc->Print(&printer);
+  xml_doc.Print(&printer);
   std::string str(printer.CStr());
 
   return Model::initString(str);
 }
 
-bool Model::initXml(tinyxml2::XMLElement *robot_xml)
+bool Model::initXml(const tinyxml2::XMLElement & robot_xml)
 {
-  if (!robot_xml) {
-    ROS_ERROR("Could not parse the xml element");
-    return false;
-  }
-
   std::stringstream ss;
   tinyxml2::XMLPrinter printer;
-  robot_xml->Accept(&printer);
+  robot_xml.Accept(&printer);
   ss << printer.CStr();
 
   return Model::initString(ss.str());

--- a/urdf/test/test_model_parser_initxml.cpp
+++ b/urdf/test/test_model_parser_initxml.cpp
@@ -85,12 +85,6 @@ TEST(model_parser_initxml, initxml_tinyxml_document_good)
   ASSERT_TRUE(model.initXml(&xml_doc));
 }
 
-TEST(model_parser_initxml, initxml_tinyxml2_element_bad)
-{
-  urdf::Model model;
-  ASSERT_FALSE(model.initXml(reinterpret_cast<tinyxml2::XMLElement *>(NULL)));
-}
-
 TEST(model_parser_initxml, initxml_tinyxml2_element_good)
 {
   tinyxml2::XMLDocument xml_doc;
@@ -100,19 +94,13 @@ TEST(model_parser_initxml, initxml_tinyxml2_element_good)
   ASSERT_TRUE(model.initXml(xml_doc.RootElement()));
 }
 
-TEST(model_parser_initxml, initxml_tinyxml2_document_bad)
-{
-  urdf::Model model;
-  ASSERT_FALSE(model.initXml(reinterpret_cast<tinyxml2::XMLDocument *>(NULL)));
-}
-
 TEST(model_parser_initxml, initxml_tinyxml2_document_good)
 {
   tinyxml2::XMLDocument xml_doc;
   xml_doc.Parse(good_robot.c_str());
 
   urdf::Model model;
-  ASSERT_TRUE(model.initXml(&xml_doc));
+  ASSERT_TRUE(model.initXml(xml_doc));
 }
 
 int main(int argc, char** argv)

--- a/urdf/test/test_model_parser_initxml.cpp
+++ b/urdf/test/test_model_parser_initxml.cpp
@@ -91,7 +91,7 @@ TEST(model_parser_initxml, initxml_tinyxml2_element_good)
   xml_doc.Parse(good_robot.c_str());
 
   urdf::Model model;
-  ASSERT_TRUE(model.initXml(xml_doc.RootElement()));
+  ASSERT_TRUE(model.initXml(*(xml_doc.RootElement())));
 }
 
 TEST(model_parser_initxml, initxml_tinyxml2_document_good)


### PR DESCRIPTION
This changes the `initXml` API to take a `const` reference to tinyxml2 objects. Changing to `const` because it can, and to a reference to eliminate the need to check for a null pointer.