### PR TITLE
class_loader.h -> class_loader.hpp

### DIFF
--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -45,7 +45,7 @@
    other parsers are loaded via plugins (if available) */
 #include <urdf_parser/urdf_parser.h>
 #include <urdf_parser_plugin/parser.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/scoped_ptr.hpp>


### PR DESCRIPTION
Eliminates a deprecation warning about the include file name