### PR TITLE
Solved problem when static linking against urdf

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -27,7 +27,7 @@ add_compile_options(-std=c++11)
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
-  CATKIN_DEPENDS rosconsole_bridge roscpp
+  CATKIN_DEPENDS pluginlib rosconsole_bridge roscpp
   DEPENDS urdfdom_headers urdfdom Boost TinyXML TinyXML2
 )
 install(FILES ${generated_compat_header} DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})


### PR DESCRIPTION
Static linking against urdf failed because of transitive linking problems. pluginlib wasn't exported in CATKIN_DEPENDS list. This solves the issue.