### PR TITLE
unit test: add missing link name

### DIFF
--- a/urdf/test/test_model_parser_initxml.cpp
+++ b/urdf/test/test_model_parser_initxml.cpp
@@ -37,7 +37,7 @@
 #include "urdf/model.h"
 
 static const std::string good_robot{"<robot name=\"myrobot\">"
-                                    "  <link>"
+                                    "  <link name=\"dummy\">"
                                     "  </link>"
                                     "</robot>"};
 


### PR DESCRIPTION
The stricter error handling of https://github.com/ros/urdfdom/pull/104 will require to provide a link name.