### PR TITLE
update deprecated macro for MSVC

### DIFF
--- a/urdf/include/urdf/visibility_control.hpp
+++ b/urdf/include/urdf/visibility_control.hpp
@@ -53,7 +53,7 @@
   #else
     #define URDF_EXPORT __declspec(dllexport)
     #define URDF_IMPORT __declspec(dllimport)
-    #define URDF_DEPRECATED(msg)
+    #define URDF_DEPRECATED(msg) __declspec(deprecated(msg))
   #endif
   #ifdef URDF_BUILDING_LIBRARY
     #define URDF_PUBLIC URDF_EXPORT

--- a/urdf/include/urdf/visibility_control.hpp
+++ b/urdf/include/urdf/visibility_control.hpp
@@ -53,7 +53,7 @@
   #else
     #define URDF_EXPORT __declspec(dllexport)
     #define URDF_IMPORT __declspec(dllimport)
-    #define URDF_DEPRECATED(msg) __attribute__((deprecated(msg)))
+    #define URDF_DEPRECATED(msg)
   #endif
   #ifdef URDF_BUILDING_LIBRARY
     #define URDF_PUBLIC URDF_EXPORT


### PR DESCRIPTION
update deprecated macro to `__declspec(deprecated(msg))` for MSVC