### PR TITLE
update compiler flags

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -22,7 +22,11 @@ set(generated_compat_header "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/urdf
 include_directories("${CATKIN_DEVEL_PREFIX}/include")
 configure_file(urdfdom_compatibility.h.in "${generated_compat_header}" @ONLY)
 
-add_compile_options(-std=c++11)
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
+if(COMPILER_SUPPORTS_CXX11)
+  add_compile_options(-std=c++11)
+endif()
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -34,6 +34,9 @@ else()
   endif()
 endif()
 
+unset(COMPILER_SUPPORTS_WARNING_NO_DEPRECATED_DECLARATIONS CACHE)
+check_cxx_compiler_flag(-Wno-deprecated-declarations COMPILER_SUPPORTS_WARNING_NO_DEPRECATED_DECLARATIONS)
+
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
@@ -73,7 +76,9 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(urdfdom_compatibility_test test/urdfdom_compatibility.cpp)
   target_link_libraries(urdfdom_compatibility_test ${PROJECT_NAME})
 
-  set_source_files_properties(test/test_model_parser_initxml.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+  if(COMPILER_SUPPORTS_WARNING_NO_DEPRECATED_DECLARATIONS)
+    set_source_files_properties(test/test_model_parser_initxml.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+  endif()
   catkin_add_gtest(test_model_parser_initxml test/test_model_parser_initxml.cpp)
   target_link_libraries(test_model_parser_initxml ${PROJECT_NAME})
 endif()

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -26,12 +26,7 @@ include(CheckCXXCompilerFlag)
 unset(COMPILER_SUPPORTS_CXX11 CACHE)
 if(MSVC)
   # https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
-  # MSVC will fail the following check since it does not have the c++11 switch
-  # however, c++11 is always enabled (the newer /std:c++14 is enabled by default)
-  check_cxx_compiler_flag(/std:c++11 COMPILER_SUPPORTS_CXX11)
-  if(COMPILER_SUPPORTS_CXX11)
-    add_compile_options(/std:c++11)
-  endif()
+  # MSVC has c++14 enabled by default, no need to specify c++11
 else()
   check_cxx_compiler_flag(-std=c++11 COMPILER_SUPPORTS_CXX11)
   if(COMPILER_SUPPORTS_CXX11)

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -23,9 +23,20 @@ include_directories("${CATKIN_DEVEL_PREFIX}/include")
 configure_file(urdfdom_compatibility.h.in "${generated_compat_header}" @ONLY)
 
 include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if(COMPILER_SUPPORTS_CXX11)
-  add_compile_options(-std=c++11)
+unset(COMPILER_SUPPORTS_CXX11 CACHE)
+if(MSVC)
+  # https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
+  # MSVC will fail the following check since it does not have the c++11 switch
+  # however, c++11 is always enabled (the newer /std:c++14 is enabled by default)
+  check_cxx_compiler_flag(/std:c++11 COMPILER_SUPPORTS_CXX11)
+  if(COMPILER_SUPPORTS_CXX11)
+    add_compile_options(/std:c++11)
+  endif()
+else()
+  check_cxx_compiler_flag(-std=c++11 COMPILER_SUPPORTS_CXX11)
+  if(COMPILER_SUPPORTS_CXX11)
+    add_compile_options(-std=c++11)
+  endif()
 endif()
 
 catkin_package(


### PR DESCRIPTION
update how `c++11` compiler flag is added:
- only add it when it's supported (tested on Ubuntu 18.04)
- add similar logic for MSVC (as mentioned in the comment, this check would fail, but c++11 is always enabled). this pattern could be helpful if later this project moves to c++14 (which is an available switch in MSVC)

the other way to do this is to use `target_compile_features(mylib PUBLIC cxx_std_11)` from [cmake](https://cmake.org/cmake/help/v3.8/manual/cmake-compile-features.7.html#requiring-language-standards), but this would mean to add this line for every target. would this be preferred instead of adding a global `c++11` flag?