### PR TITLE
set `CMAKE_CXX_STANDARD` only if newer than before

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -22,7 +22,9 @@ set(generated_compat_header "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/urdf
 include_directories("${CATKIN_DEVEL_PREFIX}/include")
 configure_file(urdfdom_compatibility.h.in "${generated_compat_header}" @ONLY)
 
-set(CMAKE_CXX_STANDARD 14)
+if(NOT DEFINED CMAKE_CXX_STANDARD OR "${CMAKE_CXX_STANDARD}" LESS 14)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 catkin_package(


### PR DESCRIPTION
On Ubuntu 22.04 everything downstream of `rosconsole`
[has to be build with C++17 enabled](https://github.com/ros/rosconsole/pull/56).

Most packages set the `CMAKE_CXX_STANDARD` before `find_package`ing,
which means that the above mentioned fix will work for them.
Unfortunately `urdf` does set the standard after including `rosconsole`
(transitively).

Instead of moving the statement before the `find_package` I decided to
check explicitly if already a higher version was set, because I think it
shows the intent more clearly.

Also there might be other reasons why somebody decides to raise the
`CMAKE_CXX_STANDARD`, which this fix will then allow.