### PR TITLE
Migrate parser plugin from boost to std::shared_ptr

### DIFF
--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -181,7 +181,7 @@ bool Model::initString(const std::string & xml_string)
       bool found = false;
       for (std::size_t i = 0 ; i < classes.size() ; ++i) {
         if (classes[i].find("urdf/ColladaURDFParser") != std::string::npos) {
-          boost::shared_ptr<urdf::URDFParser> instance = PARSER_PLUGIN_LOADER->createInstance(classes[i]);
+          auto instance = PARSER_PLUGIN_LOADER->createUniqueInstance(classes[i]);
           if (instance) {
             model = instance->parse(xml_string);
           }


### PR DESCRIPTION
This was a left-over from migration to `std::shared_ptr`.